### PR TITLE
Add sensitive flag to expose underlying "sensitive" attribute in the Chef cookbook_file resource which can suppress the install.ps1 verbosity when run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Chocolatey cookbook
 
+## v2.0.2 (2019-07-11)
+
+- Add `['chocolatey']['sensitive']` attribute (default: false) to give users the option to suppress output spam when the install.ps1 file is pushed to the machine.
+
 ## v2.0.1 (2018-07-03)
 
 - Remove mentions of the package provider from the readme and metadata

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Attribute                                            | Description              
 `['install_vars']['chocolateyVersion']`              | Version of Chocolatey to install, e.g. '0.9.9.11'                                         | String  | nil (download latest version)
 `['install_vars']['chocolateyDownloadUrl']`          | Chocolatey .nupkg file URL. Use this if you host an internal copy of the chocolatey.nupkg | String  | <https://chocolatey.org/api/v2/package/chocolatey> (download from chocolatey.org)
 `['install_vars']['chocolateyUseWindowsCompression']`| To use built-in compression instead of 7zip (requires additional download) set to `true`  | String  | nil (use 7zip)
+`['sensitive']`                                      | When true, will suppress writing the contents of install.ps1 to the console               | Boolean | false
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default['chocolatey']['upgrade'] = false
+default['chocolatey']['sensitive'] = false
 
 # Chocolatey install.ps1 env vars. See https://chocolatey.org/install.ps1
 default['chocolatey']['install_vars'].tap do |env|

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem.lettron@youscribe.com'
 license          'Apache-2.0'
 description      'Install Chocolatey on Windows'
 long_description 'Installs the Chocolatey package manager for Windows.'
-version          '2.0.1'
+version          '2.0.2'
 
 source_url 'https://github.com/chocolatey/chocolatey-cookbook'
 issues_url 'https://github.com/chocolatey/chocolatey-cookbook/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem.lettron@youscribe.com'
 license          'Apache-2.0'
 description      'Install Chocolatey on Windows'
 long_description 'Installs the Chocolatey package manager for Windows.'
-version          '2.0.2'
+version          '2.0.1'
 
 source_url 'https://github.com/chocolatey/chocolatey-cookbook'
 issues_url 'https://github.com/chocolatey/chocolatey-cookbook/issues'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ cookbook_file install_ps1 do
   action :create
   backup false
   source 'install.ps1'
+  sensitive node['chocolatey']['sensitive']
 end
 
 powershell_script 'Install Chocolatey' do


### PR DESCRIPTION
### Description

This adds an attribute to suppress the output of writing the install.ps1 file to disk.  It does *NOT* suppress the output of running the install, just the initial Chef spam where it writes the entire contents to the console.

### Issues Resolved

N/a

### Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
