### PR TITLE
Use chocolatey package for upgrade

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ install:
   - ps: iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current
   - ps: 'Get-CimInstance win32_operatingsystem -Property Caption, OSArchitecture, Version | fl Caption, OSArchitecture, Version'
   - ps: $PSVersionTable
+  - ps: '$env:CHEF_LICENSE = "accept"'
   - c:\opscode\chefdk\bin\chef.bat exec ruby --version
   - ps: secedit /export /cfg $env:temp/export.cfg
   - ps: ((get-content $env:temp/export.cfg) -replace ('PasswordComplexity = 1', 'PasswordComplexity = 0')) | Out-File $env:temp/export.cfg

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,5 +36,5 @@ powershell_script 'Install Chocolatey' do
   environment node['chocolatey']['install_vars']
   cwd Chef::Config['file_cache_path']
   code install_ps1
-  not_if { chocolatey_installed? && (node['chocolatey']['upgrade'] == false) }
+  not_if { chocolatey_installed? }
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,3 +38,9 @@ powershell_script 'Install Chocolatey' do
   code install_ps1
   not_if { chocolatey_installed? }
 end
+
+chocolatey_package 'chocolatey' do
+  action :upgrade
+  version node['chocolatey']['install_vars']['chocolateyVersion']
+  only_if { node['chocolatey']['upgrade'] }
+end


### PR DESCRIPTION
### Description

Switch to the `chocolatey_package` resource for upgrading an existing installation, because it seems to be more robust than Chocolatey's install script.

Added bonus: I also fixed the AppVeyor pipeline, which was failing because the Chef license was not being accepted.

### Issues Resolved

#12, #144 

### Check List

- [x] All tests pass, except one which also fails on the `master` branch (the `chocolatey.install_vars.chocolateyVersion` attribute seems to be ignored when installing Chocolatey).
- [ ] New functionality includes testing. -> There is no new functionality, but the re-implemented functionality does not have any tests. Since testing this functionality would require some multiple converge scenarios, it seems that writing tests for this would be pretty complicated to achieve, and beyond the effort I want to put into this PR. If anyone does feel like writing the tests, they are free to build upon my PR/branch.
- [x] New functionality has been documented in the README if applicable -> There is no new functionality.
