### PR TITLE
Avoid no-op resource logs if upgrade isn't set

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,8 +40,9 @@ powershell_script 'Install Chocolatey' do
   not_if { chocolatey_installed? }
 end
 
-chocolatey_package 'chocolatey' do
-  action :upgrade
-  version node['chocolatey']['install_vars']['chocolateyVersion']
-  only_if { node['chocolatey']['upgrade'] }
+if node['chocolatey']['upgrade']
+  chocolatey_package 'chocolatey' do
+    action :upgrade
+    version node['chocolatey']['install_vars']['chocolateyVersion']
+  end
 end


### PR DESCRIPTION
Let's not log a chocolatey resource if upgrade wasn't set

Signed-off-by: Tim Smith <tsmith@chef.io>